### PR TITLE
Proposition d'ajout d'un code de conduite

### DIFF
--- a/chantiers/code-of-conduct/coc-12-ressources-inspirantes.md
+++ b/chantiers/code-of-conduct/coc-12-ressources-inspirantes.md
@@ -14,9 +14,14 @@
 - [Code of Conduct de 18F (USA)](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md)  
 - [confcodeofconduct.com](http://confcodeofconduct.com/)
 - [FFS Tech Conférence](https://docs.google.com/document/d/e/2PACX-1vSiqCZpBdx028N3rQ7QO1LfQGGp31IEPVQjXKSuAdBd2CXPV8YQtd2Mm2Fwc6iQLQQLzVffijI25Pfg/pub)
+- [Code de conduite de Distributed Proofreaders](https://www.pgdp.net/wiki/DP_Official_Documentation:General/French/Code_de_Conduite) 
 
 
 [Ici](https://github.com/Rookie-Club/katas/community), Github propose des trucs à faire pour bien fonctionner avec les contribut·eur·rice·s d'un répertoire. Dans le tas, il propose notamment de créer un Code of Conduct. On y trouve : 
 - [Un document explique ce qu'est un CoC](https://help.github.com/articles/adding-a-code-of-conduct-to-your-project/) et comment le créer dans le répertoire. [Ici la version traduite en français](https://github.com/Julia-barbelane/reflexions/blob/master/chantiers/code-of-conduct/traductions/github-pq-et-cmt.md)  
 - [Un premier exemple](https://github.com/Rookie-Club/katas/community/code-of-conduct/new?template=contributor-covenant) de CoC. [Ici la version traduite en français](https://github.com/Julia-barbelane/reflexions/blob/master/chantiers/code-of-conduct/traductions/github-exemple-1.md)  
 - [Un deuxième exemple](https://github.com/Rookie-Club/katas/community/code-of-conduct/new?template=citizen-code-of-conduct) de CoC. [ici la version traduite en français](https://github.com/Julia-barbelane/reflexions/blob/master/chantiers/code-of-conduct/traductions/github-exemple-2.md)  
+
+
+
+


### PR DESCRIPTION
Il s'agit du code de conduite d'une communauté bénévole qui travail principalement en ligne (si j'ai bien suivi) : Distributed Proofreaders. 

Je ne sais pas si c'est pertinant d'ajouter ce genre de référence ici ?